### PR TITLE
Make deployment work only for main branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,3 +29,7 @@ workflows:
   heroku_deploy:
     jobs:
       - heroku/deploy-via-git
+          filters:
+            branches:
+              only:
+                - main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ workflows:
       - say-hello
   heroku_deploy:
     jobs:
-      - heroku/deploy-via-git
+      - heroku/deploy-via-git:
           filters:
             branches:
               only:


### PR DESCRIPTION
I noticed that the app is deployed every time we push (regardless of which branch), which might cause later problems. I made it deploy the code only when we push to main (which in most cases means after we had a reviewed pull request). This needs testing after merging!